### PR TITLE
Add compatibility layer for Windows (MSVC)

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -7,7 +7,7 @@ project(piper C CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-ADD_EXECUTABLE(piper main.cpp)
+ADD_EXECUTABLE(piper main.cpp compat.cpp)
 
 string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wl,-rpath,'$ORIGIN'")
 string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")

--- a/src/cpp/compat.cpp
+++ b/src/cpp/compat.cpp
@@ -1,0 +1,23 @@
+#include <filesystem>
+#include <string>
+
+#if _MSC_VER
+#include <windows.h>
+
+namespace {
+  std::string wstringToString(const std::wstring& ws) {
+    char tmpMb[4096];
+    const int len = WideCharToMultiByte(CP_ACP, 0, ws.c_str(), -1, tmpMb, (int) sizeof(tmpMb), NULL, NULL);
+    tmpMb[len] = 0;
+    return std::string(tmpMb);
+  }
+}
+
+std::string compat_filesystem_path_to_string(std::filesystem::path path) {
+  return wstringToString(path);
+}
+#else
+std::string compat_filesystem_path_to_string(std::filesystem::path path) {
+  return path;
+}
+#endif

--- a/src/cpp/compat.hpp
+++ b/src/cpp/compat.hpp
@@ -1,0 +1,8 @@
+#ifndef COMPAT_HPP_
+#define COMPAT_HPP_
+#include <filesystem>
+#include <string>
+
+std::string compat_filesystem_path_to_string(std::filesystem::path path);
+
+#endif

--- a/src/cpp/model.hpp
+++ b/src/cpp/model.hpp
@@ -19,7 +19,7 @@ struct ModelSession {
   ModelSession() : onnx(nullptr){};
 };
 
-void loadModel(string modelPath, ModelSession &session) {
+void loadModel(filesystem::path modelPath, ModelSession &session) {
 
   session.env = Ort::Env(OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING,
                          instanceName.c_str());

--- a/src/cpp/piper.hpp
+++ b/src/cpp/piper.hpp
@@ -14,6 +14,7 @@
 #include "phonemize.hpp"
 #include "synthesize.hpp"
 #include "wavfile.hpp"
+#include "compat.hpp"
 
 using json = nlohmann::json;
 
@@ -28,17 +29,19 @@ struct Voice {
 };
 
 void initialize(std::filesystem::path cwd) {
-  const char *dataPath = NULL;
+  std::filesystem::path dataPath;
 
   auto cwdDataPath = cwd.append("espeak-ng-data");
   if (std::filesystem::is_directory(cwdDataPath)) {
-    dataPath = cwdDataPath.c_str();
+    dataPath = cwdDataPath;
   }
+
+  std::string espeakDataPath = compat_filesystem_path_to_string(dataPath);
 
   // Set up espeak-ng for calling espeak_TextToPhonemes
   int result = espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS,
                                  /*buflength*/ 0,
-                                 /*path*/ dataPath,
+                                 /*path*/ espeakDataPath.c_str(),
                                  /*options*/ 0);
   if (result < 0) {
     throw runtime_error("Failed to initialize eSpeak-ng");


### PR DESCRIPTION
On Windows, `std::filesystem::path::value_type` is `wchar_t`. Therefore we can't use `path.c_str()` as `char*` directly.
This changeset adds WIN32 `wstring` -> MB string conversion function to mitigate this issue.

Note that I think this is not a ideal solution.  It may need to introduce path agnostic or fully native (char/wchar_t) path API for initialization of espeak-ng.

This PR also partially resolves #24.  With this patch, I've successfully build piper on VS2022.
