### PR TITLE
Improve path related compatibility in C++

### DIFF
--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -15,6 +15,12 @@
 #include <pcaudiolib/audio.h>
 #endif
 
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #include "piper.hpp"
 
 using namespace std;
@@ -54,7 +60,15 @@ int main(int argc, char *argv[]) {
   parseArgs(argc, argv, runConfig);
 
   // NOTE: This won't work for Windows (need GetModuleFileName)
+#ifdef _MSC_VER
+  auto exePath = []() {
+    wchar_t moduleFileName[MAX_PATH] = { 0 };
+    GetModuleFileNameW(nullptr, moduleFileName, std::size(moduleFileName));
+    return filesystem::path(moduleFileName);
+  }();
+#else
   auto exePath = filesystem::canonical("/proc/self/exe");
+#endif
   piper::initialize(exePath.parent_path());
 
   piper::Voice voice;

--- a/src/cpp/model.hpp
+++ b/src/cpp/model.hpp
@@ -43,7 +43,7 @@ void loadModel(string modelPath, ModelSession &session) {
   session.options.DisableProfiling();
 
   auto startTime = chrono::steady_clock::now();
-  session.onnx = Ort::Session(session.env, modelPath.c_str(), session.options);
+  session.onnx = Ort::Session(session.env, filesystem::path(modelPath).c_str(), session.options);
   auto endTime = chrono::steady_clock::now();
   auto loadDuration = chrono::duration<double>(endTime - startTime);
 }

--- a/src/cpp/piper.hpp
+++ b/src/cpp/piper.hpp
@@ -28,17 +28,19 @@ struct Voice {
 };
 
 void initialize(std::filesystem::path cwd) {
-  const char *dataPath = NULL;
+  string dataPath;
 
   auto cwdDataPath = std::filesystem::absolute(cwd.append("espeak-ng-data"));
   if (std::filesystem::is_directory(cwdDataPath)) {
-    dataPath = cwdDataPath.c_str();
+    dataPath = cwdDataPath.string();
   }
+
+	cerr << "dataPath: " << dataPath << endl;
 
   // Set up espeak-ng for calling espeak_TextToPhonemes
   int result = espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS,
                                  /*buflength*/ 0,
-                                 /*path*/ dataPath,
+                                 /*path*/ dataPath.c_str(),
                                  /*options*/ 0);
   if (result < 0) {
     throw runtime_error("Failed to initialize eSpeak-ng");


### PR DESCRIPTION
This PR mainly aims to support MSVC/Windows environment.  It contains the following changes.

- (1) Retrieve exePath by `GetModuleFileNameW()` as suggested in the comment.
- (2) Since `ORTCHAR_T` != `char`, use `std::filesystem::path::value_type` instead of using `char` directly.
- (3) espeak-ng internally uses `fopen()`.  And its filepath is `const char*`.  So, `std::filesystem::path::string()` provides better compatibility with piper CLI's internal path and `char*`.  It may support UTF-8, ASCII, [MBCS](https://learn.microsoft.com/en-us/cpp/text/unicode-and-mbcs), etc.


If someone want to try this patch, they can use my fork/branch for this PR with this procedure: https://gist.github.com/t-mat/84cb1b8a828a0eee6d7db37f7ff75f70?permalink_comment_id=4545947#gistcomment-4545947
