### PR TITLE
Fix compilation and runtime for M1 Mac

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -31,9 +31,12 @@ set(ONNXRUNTIME_ROOTDIR ${CMAKE_CURRENT_LIST_DIR}/../../lib/${CMAKE_HOST_SYSTEM_
 target_link_libraries(piper
                       onnxruntime
                       pthread
-                      -static-libgcc -static-libstdc++
                       ${ESPEAK_NG_LIBRARIES}
                       ${PCAUDIO_LIBRARIES})
+
+if(NOT APPLE)
+  target_link_libraries(-static-libgcc -static-libstdc++)
+endif()
 
 target_link_directories(piper PUBLIC
                         ${ESPEAK_NG_LIBRARY_DIRS}

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -21,6 +21,10 @@
 #include <windows.h>
 #endif
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
 #include "piper.hpp"
 
 using namespace std;
@@ -67,7 +71,16 @@ int main(int argc, char *argv[]) {
     return filesystem::path(moduleFileName);
   }();
 #else
+#ifdef __APPLE__
+  auto exePath = []() {
+    char moduleFileName[PATH_MAX] = { 0 };
+    uint32_t moduleFileNameSize = std::size(moduleFileName);
+    _NSGetExecutablePath(moduleFileName, &moduleFileNameSize);
+    return filesystem::path(moduleFileName);
+  }();
+#else
   auto exePath = filesystem::canonical("/proc/self/exe");
+#endif
 #endif
   piper::initialize(exePath.parent_path());
 


### PR DESCRIPTION
This cleans up a couple of minor issues using Piper on an M1 Mac.  In CMakeLists.txt, two of the flags cannot be used because Mac OS's gcc is actually clang.  /proc/self/exe also does not exist, so an additional condition for getting the moduleFileName is added to main.cpp.

I've tested this is compiling on an M1 Mac and capable of generating working output with these changes.