### PR TITLE
[Fix] speaker_id was always 0/None

### DIFF
--- a/src/python_run/piper/__init__.py
+++ b/src/python_run/piper/__init__.py
@@ -87,7 +87,7 @@ class Piper:
             dtype=np.float32,
         )
 
-        if (self.config.num_speakers > 1) and (speaker_id is not None):
+        if (self.config.num_speakers > 1) and (speaker_id is None):
             # Default speaker
             speaker_id = 0
 


### PR DESCRIPTION
- Wrong condition put 0 for a specified value and let None pass

Fixes #117 