### PR TITLE
Fix checking voice files in custom data dirs

### DIFF
--- a/src/python_run/piper/download.py
+++ b/src/python_run/piper/download.py
@@ -83,24 +83,22 @@ def ensure_voice_exists(
             actual_size = data_file_path.stat().st_size
             if expected_size != actual_size:
                 _LOGGER.warning(
-                    "Deleting model file with wrong size (expected=%s, actual=%s) for %s",
+                    "Skipping model file with wrong size (expected=%s, actual=%s) for %s",
                     expected_size,
                     actual_size,
                     data_file_path,
                 )
-                Path(data_file_path).unlink(missing_ok=True)
                 continue
 
             expected_hash = file_info["md5_digest"]
             actual_hash = get_file_hash(data_file_path)
             if expected_hash != actual_hash:
                 _LOGGER.warning(
-                    "Deleting model file with wrong hash (expected=%s, actual=%s) for %s",
+                    "Skipping model file with wrong hash (expected=%s, actual=%s) for %s",
                     expected_hash,
                     actual_hash,
                     data_file_path,
                 )
-                Path(data_file_path).unlink(missing_ok=True)
                 continue
 
             file_found = True


### PR DESCRIPTION
This fixes piper re-downloading already downloaded models with the --data-dir option. It now checks for every model if it exists in one of the data dirs. It only downloads models if they are actually missing, or if all existing files were invalid.

Without this fix, piper schedules a model file for download if it is missing in _any_ data directory. As "." is always in the list of data dirs, models are re-downloaded if they don't exist in the current working dir. With this fix, it only downloads files that are missing in _all_ data dirs.