### PR TITLE
Fix multiarch builds on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
           asset_content_type: application/zip
   build_macos:
     name: "macos build: ${{ matrix.arch }}"
-    runs-on: macos-latest
+    runs-on: ${{ matrix.arch == 'x64' && 'macos-13' || 'macos-latest' }}
     needs: create_release # we need to know the upload URL
     strategy:
       fail-fast: true


### PR DESCRIPTION
The `build_macos` actions workflow incorrectly tried to build both the Intel and Apple Silicon executables on the same macOS runner. At the time of the last release, this built a pair of identical x86_64 binaries because `macos-latest` pointed at an Intel machine. If one were to run a release today, this would build a pair of identical arm64 binaries because `macos-latest` now points at a modern Mac.

As a result, **the Apple Silicon release of piper has been broken on new macs for at least a year**.

This PR uses the older `macos-13` runners for the x86_64 build and `macos-latest` for the arm64 build. I made a test release at https://github.com/dharmab/piper/releases/tag/2024.12.14.1-alpha2 that seems to work:

```
[dharmab@saber Downloads] tar xf piper_macos_x64.tar.gz
[dharmab@saber Downloads] file piper/piper
piper/piper: Mach-O 64-bit executable x86_64
[dharmab@saber Downloads] rm -rf piper
[dharmab@saber Downloads] tar xf piper_macos_aarch64.tar.gz
[dharmab@saber Downloads] file piper/piper
piper/piper: Mach-O 64-bit executable arm64
```

A new release will need to be tagged after this PR is merged.

Fixes https://github.com/rhasspy/piper/issues/523
Fixes https://github.com/rhasspy/piper/issues/480
Fixes https://github.com/rhasspy/piper/issues/284