### PR TITLE
Allow for synthesize to be called again for the same wav_file

### DIFF
--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -97,9 +97,26 @@ class PiperVoice:
         sentence_silence: float = 0.0,
     ):
         """Synthesize WAV audio from text."""
-        wav_file.setframerate(self.config.sample_rate)
-        wav_file.setsampwidth(2)  # 16-bit
-        wav_file.setnchannels(1)  # mono
+
+        # only set parameters if they are not set yet.
+        # This allows to call this function for the same wave files multiple times
+        try:
+            wav_file.setframerate(self.config.sample_rate)
+        except wave.Error:
+            if wav_file.getframerate() != self.config.sample_rate:
+                raise RuntimeError("wav_file has invalid framerate set")
+
+        try:
+            wav_file.setsampwidth(2)  # 16-bit
+        except wave.Error:
+            if wav_file.getsampwidth() != 2:
+                raise RuntimeError("wav_file has invalid sampwidth set")
+
+        try:
+            wav_file.setnchannels(1)  # mono
+        except wave.Error:
+            if wav_file.getnchannels() != 1:
+                raise RuntimeError("wav_file has invalid nchannels set")
 
         for audio_bytes in self.synthesize_stream_raw(
             text,


### PR DESCRIPTION
Currently you can not call `synthesize` multiple times for the same wav file.
So doing stuff like creating some tts with `model a` and then appending some tts with `model b` is not possible, because setting wav parameter, after some frames where written is not allowed (throws a `wave.Error`)

This change makes sure to catch the possible error, but still ensures the parameter in `wav_file` are still correctly set for the used model.