### PR TITLE
docs: Specify pip==24.0 in installation instructions

### DIFF
--- a/TRAINING.md
+++ b/TRAINING.md
@@ -36,7 +36,7 @@ Then create a Python virtual environment:
 cd piper/src/python
 python3 -m venv .venv
 source .venv/bin/activate
-pip3 install --upgrade pip
+python3 -m pip install pip==24.0
 pip3 install --upgrade wheel setuptools
 pip3 install -e .
 ```


### PR DESCRIPTION
**Context**:  
Some environments encounter installation failures with newer `pip` versions  (`pip`>=24.1).

**Changes**:  
- Pins `pip==24.0` in the setup steps (a version confirmed to work in testing).  

This update ensures a smoother installation experience but does not modify functional code.  