### PR TITLE
strip newline from version variable, otherwise the newline in the variable breaks ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 project(piper C CXX)
 
 file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" piper_version)
+string(STRIP "${piper_version}" piper_version)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Strip newline from version variable, otherwise the newline in the variable breaks ninja.

The newline symbol becomes a `$` in `.ninja` and then breaks the generated compiler invocations.